### PR TITLE
ci: add id-token permission to pr-preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -8,6 +8,8 @@ permissions:
   contents: read
   pull-requests: write
   deployments: write
+  pages: write
+  id-token: write
 
 jobs:
   deploy:


### PR DESCRIPTION
This PR adds the necessary id-token: write and pages: write permissions to the pr-preview.yml workflow. This is required by the actions/deploy-pages@v4 action to fix the OIDC authentication error.